### PR TITLE
Fix invalid local uploads path

### DIFF
--- a/packages/strapi-provider-upload-local/lib/index.js
+++ b/packages/strapi-provider-upload-local/lib/index.js
@@ -23,6 +23,10 @@ module.exports = {
         });
       }
     };
+    const getStaticPath = () => path.join(
+      strapi.dir,
+      strapi.config.middleware.settings.public.path || strapi.config.paths.static
+    );
 
     return {
       upload(file) {
@@ -31,7 +35,7 @@ module.exports = {
         return new Promise((resolve, reject) => {
           // write file in public/assets folder
           fs.writeFile(
-            path.join(strapi.config.paths.static, `/uploads/${file.hash}${file.ext}`),
+            path.join(getStaticPath(), `/uploads/${file.hash}${file.ext}`),
             file.buffer,
             err => {
               if (err) {
@@ -48,7 +52,7 @@ module.exports = {
       delete(file) {
         return new Promise((resolve, reject) => {
           const filePath = path.join(
-            strapi.config.paths.static,
+            getStaticPath(),
             `/uploads/${file.hash}${file.ext}`
           );
 


### PR DESCRIPTION
File upload provider does not consider the strapi configuration. This patch should fix the problem.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:
```js
const path = require('path');
const strapiDir = path.join(__dirname, './backend');

const Strapi = require(path.join(strapiDir, `/node_modules/strapi`));
const strapi = Strapi({
  dir: strapiDir
});
strapi.start();
```
This configuration generates the following error when uploading the image:
```
ENOENT: no such file or directory, open 'C:\Users\XYZ\Desktop\backend\public\uploads\screenshot_862571e640.jpeg'
```
The correct directory should be:
```
C:\Users\XYZ\Desktop\app\backend\public\uploads\screenshot_862571e640.jpeg
```